### PR TITLE
xorg-server: add loongson GPU fixes for the modesetting driver

### DIFF
--- a/xorg-server/0001-modesetting-match-against-Multimedia-Video-Controlle.patch
+++ b/xorg-server/0001-modesetting-match-against-Multimedia-Video-Controlle.patch
@@ -1,0 +1,32 @@
+From 4eda654b6099981294b35bd93c1e4e92e71f376a Mon Sep 17 00:00:00 2001
+From: "Liu, Chang" <cl91tp@gmail.com>
+Date: Wed, 8 Nov 2023 13:02:10 +0800
+Subject: [PATCH] modesetting: match against Multimedia Video Controllers as
+ well
+
+Some GPU devices such as those found in the Loongson 7A2000 bridge
+chips and 2K2000 SOCs identify as Multimedia Video Controllers
+(PCI class 0x4 subclass 0x0). These have standard KMS drivers in
+the kernel and the modesetting driver works flawlessly, so match
+against these types of devices as well.
+---
+ hw/xfree86/drivers/modesetting/driver.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hw/xfree86/drivers/modesetting/driver.c b/hw/xfree86/drivers/modesetting/driver.c
+index 9a69452bd..69a2b683f 100644
+--- a/hw/xfree86/drivers/modesetting/driver.c
++++ b/hw/xfree86/drivers/modesetting/driver.c
+@@ -96,6 +96,9 @@ static const struct pci_id_match ms_device_match[] = {
+     {
+      PCI_MATCH_ANY, PCI_MATCH_ANY, PCI_MATCH_ANY, PCI_MATCH_ANY,
+      0x00030000, 0x00ff0000, 0},
++    {
++     PCI_MATCH_ANY, PCI_MATCH_ANY, PCI_MATCH_ANY, PCI_MATCH_ANY,
++     0x00040000, 0x00ff0000, 0},
+ 
+     {0, 0, 0},
+ };
+-- 
+2.42.0
+

--- a/xorg-server/10-modeset.conf
+++ b/xorg-server/10-modeset.conf
@@ -1,0 +1,6 @@
+Section "Device"
+	Identifier "Generic Kernel Modesetting Device"
+	Driver "modesetting"
+	Option "kmsdev" "/dev/dri/card0"
+	Option "ShadowFB" "true"
+EndSection

--- a/xorg-server/PKGBUILD
+++ b/xorg-server/PKGBUILD
@@ -20,7 +20,9 @@ makedepends=('xorgproto' 'pixman' 'libx11' 'mesa' 'mesa-libgl' 'xtrans'
 source=(https://xorg.freedesktop.org/releases/individual/xserver/${pkgbase}-${pkgver}.tar.xz{,.sig}
         xvfb-run # with updates from FC master
         xvfb-run.1
+        10-modeset.conf
         xephyr_Dont_check_for_SeatId_anymore.patch
+        0001-modesetting-match-against-Multimedia-Video-Controlle.patch
         0001-present-Send-a-PresentConfigureNotify-event-for-dest.patch
 )
 validpgpkeys=('3C2C43D9447D5938EF4551EBE23B7E70B467F0BF'  # Peter Hutterer (Who-T) <office@who-t.net>
@@ -30,7 +32,9 @@ sha512sums=('6104b3620ed2e1e27d9a8e963388bbe8785a764585b1bc03dbf5d719a92894773dd
             'SKIP'
             '672375cb5028ba9cda286e317d17bd8c9a9039483e7f79c21f223fd08ba07655729e9f59a082f4b8f5d8de45a77a9e9affce1002fb8c6657e26ef1a490654e49'
             'de5e2cb3c6825e6cf1f07ca0d52423e17f34d70ec7935e9dd24be5fb9883bf1e03b50ff584931bd3b41095c510ab2aa44d2573fd5feaebdcb59363b65607ff22'
+            '1aa711f4948cd1557d77bd47a64ea92be55cf737b8204214c6c3ae2ecd00dc6928fd7a789d1aa5faaff5d6162f895a41efd332e8f1710d0a7c9b33326b057ec5'
             '34de52147054535256f35143d321e4d5e189baae502afca2bd3291094946dbead0829b1f196ae2a4d23bd6d0e1e04b65a387dee43f12dee55d247e37aec419d7'
+            '0e55cc994dd8f1309c6ea40cb1f5b2d763d850a466c9d30bd8619fd68ce369b19f098d28ab684db1bd2758a6402654cf93188651e863f0e1be4eed8cf9b40e14'
             'bc7d054bef2b4550d067b3abb14eb7c534e5022ba0b0e59e14687886fe204914757b014c31150bce705baed5d8cb1be87e8624da43cb1fe874b138ced00ee18b')
 
 prepare() {
@@ -40,6 +44,8 @@ prepare() {
   patch -Np1 -i ../xephyr_Dont_check_for_SeatId_anymore.patch
   # upstream fix (merged)
   patch -Np1 -i ../0001-present-Send-a-PresentConfigureNotify-event-for-dest.patch
+  # fix modesetting driver for loongson and gsgpu
+  patch -Np1 -i ../0001-modesetting-match-against-Multimedia-Video-Controlle.patch
 }
 
 build() {
@@ -59,6 +65,7 @@ build() {
     -D xephyr=true \
     -D glamor=true \
     -D udev=true \
+    -D udev_kms=true \
     -D dtrace=false \
     -D systemd_logind=true \
     -D suid_wrapper=true \
@@ -120,6 +127,7 @@ package_xorg-server() {
 
   # distro specific files must be installed in /usr/share/X11/xorg.conf.d
   install -m755 -d "${pkgdir}/etc/X11/xorg.conf.d"
+  install -m644 -Dt "${pkgdir}/usr/share/X11/xorg.conf.d" 10-modeset.conf
 
   # license
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" "${pkgbase}-${pkgver}"/COPYING


### PR DESCRIPTION
This commit fixes the xf86-video-modesetting driver for the GPU device in the Loongson 7A2000 bridge chip. There are two fixes:

1. Enable udev_kms when configuring the package. This is needed so the platform bus support is compiled for the modesetting driver.
2. Patch the modesetting driver to accept the PCI device class 0x4 subclass 0x0 (Multimedia Video Controllers). This is because the GPUs in LS7A2000 identifies as a Multimedia Video Controller.

With these changes the modesetting driver works flawlessly against both the upstream loongson KMS driver as well as the gsgpu kernel driver that I maintain.