### PR TITLE
libvirt: add LoongArch support

### DIFF
--- a/libvirt/PKGBUILD
+++ b/libvirt/PKGBUILD
@@ -7,7 +7,7 @@
 pkgname=(libvirt libvirt-storage-gluster libvirt-storage-iscsi-direct)
 epoch=1
 pkgver=9.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc="API for controlling virtualization engines (openvz,kvm,qemu,virtualbox,xen,etc)"
 arch=('loong64' 'x86_64')
 url="https://libvirt.org/"
@@ -82,13 +82,16 @@ backup=(
 )
 source=(
   "https://libvirt.org/sources/$pkgname-$pkgver.tar.xz"{,.asc}
+  libvirt-loongarch.patch
 )
 sha256sums=('d8c758fe7db640f572489caa8ea6dd8262d169a4372326c23a3a013cdc40b8ce'
-            'SKIP')
+            'SKIP'
+            'f0562941282b157e2ebba9d203c33f4f9c0f3f93562129448f7de6e5df0575fc')
 validpgpkeys=('453B65310595562855471199CA68BE8010084C9C') # Jiří Denemark <jdenemar@redhat.com>
 
 prepare() {
   cd "$pkgname-$pkgver"
+  patch -Np1 -i ../libvirt-loongarch.patch
 
   sed -i 's|/sysconfig/|/conf.d/|g' \
     src/remote/libvirtd.service.in \

--- a/libvirt/libvirt-loongarch.patch
+++ b/libvirt/libvirt-loongarch.patch
@@ -1,0 +1,407 @@
+diff --git a/src/conf/schemas/basictypes.rng b/src/conf/schemas/basictypes.rng
+index 26eb538077..04f032b3ab 100644
+--- a/src/conf/schemas/basictypes.rng
++++ b/src/conf/schemas/basictypes.rng
+@@ -470,6 +470,7 @@
+       <value>x86_64</value>
+       <value>xtensa</value>
+       <value>xtensaeb</value>
++      <value>loongarch64</value>
+     </choice>
+   </define>
+ 
+diff --git a/src/cpu/cpu.c b/src/cpu/cpu.c
+index bc43aa4e93..dd677ba269 100644
+--- a/src/cpu/cpu.c
++++ b/src/cpu/cpu.c
+@@ -28,6 +28,7 @@
+ #include "cpu_s390.h"
+ #include "cpu_arm.h"
+ #include "cpu_riscv64.h"
++#include "cpu_loongarch64.h"
+ #include "capabilities.h"
+ 
+ 
+@@ -41,6 +42,7 @@ static struct cpuArchDriver *drivers[] = {
+     &cpuDriverS390,
+     &cpuDriverArm,
+     &cpuDriverRiscv64,
++    &cpuDriverLoongarch64,
+ };
+ 
+ 
+diff --git a/src/cpu/cpu_loongarch64.c b/src/cpu/cpu_loongarch64.c
+new file mode 100644
+index 0000000000..cf026258f9
+--- /dev/null
++++ b/src/cpu/cpu_loongarch64.c
+@@ -0,0 +1,74 @@
++/*
++ * cpu_loongarch64.c: CPU driver for loongarch64 CPUs
++ *
++ * Copyright (c) 2023, XinmuTouhouKyou
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library.  If not, see
++ * <http://www.gnu.org/licenses/>.
++ */
++
++#include <config.h>
++#include "cpu.h"
++#include "cpu_loongarch64.h"
++
++
++static const virArch archs[] = { VIR_ARCH_LOONGARCH64 };
++static virCPUCompareResult
++virCPULoongarch64Compare(virCPUDef *host G_GNUC_UNUSED,
++                  virCPUDef *cpu G_GNUC_UNUSED,
++                  bool failMessages G_GNUC_UNUSED)
++{
++    /* loongarch64 relies on QEMU to perform all runability checking. Return
++     * VIR_CPU_COMPARE_IDENTICAL to bypass Libvirt checking.
++     */
++    return VIR_CPU_COMPARE_IDENTICAL;
++}
++
++static int
++virCPULoongarch64ValidateFeatures(virCPUDef *cpu G_GNUC_UNUSED)
++{
++    return 0;
++}
++
++static int
++virCPULoongarch64Update(virCPUDef *guest,
++                  const virCPUDef *host G_GNUC_UNUSED,
++                  bool relative G_GNUC_UNUSED)
++{
++    g_autoptr(virCPUDef) updated = virCPUDefCopyWithoutModel(guest);
++
++    if (!relative || guest->mode != VIR_CPU_MODE_HOST_MODEL)
++        return 0;
++
++    updated->mode = VIR_CPU_MODE_CUSTOM;
++    virCPUDefCopyModel(updated, host, true);
++
++    virCPUDefStealModel(guest, updated, false);
++    guest->mode = VIR_CPU_MODE_CUSTOM;
++    guest->match = VIR_CPU_MATCH_EXACT;
++
++    return 0;
++}
++
++struct cpuArchDriver cpuDriverLoongarch64 = {
++    .name = "loongarch64",
++    .arch = archs,
++    .narch = G_N_ELEMENTS(archs),
++    .compare    = virCPULoongarch64Compare,
++    .decode     = NULL,
++    .encode     = NULL,
++    .baseline   = NULL,
++    .update     = virCPULoongarch64Update,
++    .validateFeatures = virCPULoongarch64ValidateFeatures,
++};
+diff --git a/src/cpu/cpu_loongarch64.h b/src/cpu/cpu_loongarch64.h
+new file mode 100644
+index 0000000000..a5f84b5637
+--- /dev/null
++++ b/src/cpu/cpu_loongarch64.h
+@@ -0,0 +1,25 @@
++/*
++ * cpu_loongarch64.h: CPU driver for loongarch64 CPUs
++ *
++ * Copyright (c) 2023, XinmuTouhouKyou
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library.  If not, see
++ * <http://www.gnu.org/licenses/>.
++ */
++
++#pragma once
++
++#include "cpu.h"
++
++extern struct cpuArchDriver cpuDriverLoongarch64;
+diff --git a/src/cpu/meson.build b/src/cpu/meson.build
+index 55396903b9..09c02ef9d9 100644
+--- a/src/cpu/meson.build
++++ b/src/cpu/meson.build
+@@ -6,6 +6,7 @@ cpu_sources = [
+   'cpu_riscv64.c',
+   'cpu_s390.c',
+   'cpu_x86.c',
++  'cpu_loongarch64.c',
+ ]
+ 
+ cpu_lib = static_library(
+diff --git a/src/cpu_map/index.xml b/src/cpu_map/index.xml
+index d2c5af5797..92948cd213 100644
+--- a/src/cpu_map/index.xml
++++ b/src/cpu_map/index.xml
+@@ -119,4 +119,8 @@
+     <include filename='arm_FT-2000plus.xml'/>
+     <include filename='arm_Tengyun-S2500.xml'/>
+   </arch>
++  <arch name='loongarch64'>
++    <include filename='loongarch64_vendors.xml'/>
++    <include filename='loongarch64_la464.xml'/>
++  </arch>
+ </cpus>
+diff --git a/src/cpu_map/loongarch64_la464.xml b/src/cpu_map/loongarch64_la464.xml
+new file mode 100644
+index 0000000000..3d4f34ae7a
+--- /dev/null
++++ b/src/cpu_map/loongarch64_la464.xml
+@@ -0,0 +1,5 @@
++<cpus>
++  <model name='la464'>
++    <decode host='on' guest='on'/>
++  </model>
++</cpus>
+diff --git a/src/cpu_map/loongarch64_vendors.xml b/src/cpu_map/loongarch64_vendors.xml
+new file mode 100644
+index 0000000000..64d49a9662
+--- /dev/null
++++ b/src/cpu_map/loongarch64_vendors.xml
+@@ -0,0 +1,3 @@
++<cpus>
++  <vendor name='Loongson'/>
++</cpus>
+\ No newline at end of file
+diff --git a/src/cpu_map/meson.build b/src/cpu_map/meson.build
+index ae5293e85f..6bce65f0fb 100644
+--- a/src/cpu_map/meson.build
++++ b/src/cpu_map/meson.build
+@@ -84,6 +84,8 @@ cpumap_data = [
+   'x86_vendors.xml',
+   'x86_Westmere-IBRS.xml',
+   'x86_Westmere.xml',
++  'loongarch64_vendors.xml',
++  'loongarch64_la464.xml',
+ ]
+ 
+ install_data(cpumap_data, install_dir: pkgdatadir / 'cpu_map')
+diff --git a/src/qemu/qemu_capabilities.c b/src/qemu/qemu_capabilities.c
+index 83119e871a..6c6eae0b66 100644
+--- a/src/qemu/qemu_capabilities.c
++++ b/src/qemu/qemu_capabilities.c
+@@ -1138,7 +1138,7 @@ virQEMUCapsInitGuestFromBinary(virCaps *caps,
+                                       NULL, NULL, 0, NULL);
+     }
+ 
+-    if ((ARCH_IS_X86(guestarch) || guestarch == VIR_ARCH_AARCH64))
++    if ((ARCH_IS_X86(guestarch) || guestarch == VIR_ARCH_AARCH64 ||  guestarch == VIR_ARCH_LOONGARCH64))
+         virCapabilitiesAddGuestFeatureWithToggle(guest, VIR_CAPS_GUEST_FEATURE_TYPE_ACPI,
+                                                  true, true);
+ 
+@@ -2697,6 +2697,10 @@ static const char *preferredMachines[] =
+ 
+     "sim", /* VIR_ARCH_XTENSA */
+     "sim", /* VIR_ARCH_XTENSAEB */
++
++
++//  "virt", /* VIR_ARCH_LOONGARCH32 */
++    "virt", /* VIR_ARCH_LOONGARCH64 */
+ };
+ G_STATIC_ASSERT(G_N_ELEMENTS(preferredMachines) == VIR_ARCH_LAST);
+ 
+diff --git a/src/qemu/qemu_domain.c b/src/qemu/qemu_domain.c
+index 413f67577e..29a78127ea 100644
+--- a/src/qemu/qemu_domain.c
++++ b/src/qemu/qemu_domain.c
+@@ -4221,7 +4221,12 @@ qemuDomainDefAddDefaultDevices(virQEMUDriver *driver,
+         if (qemuDomainIsMipsMalta(def))
+             addPCIRoot = true;
+         break;
+-
++    case VIR_ARCH_LOONGARCH64:
++        if (qemuDomainIsLoongarch64Virt(def)) {
++            addPCIRoot = true;
++            addDefaultUSB = true;
++        }
++        break;
+     case VIR_ARCH_ARMV7B:
+     case VIR_ARCH_CRIS:
+     case VIR_ARCH_ITANIUM:
+@@ -8901,6 +8906,20 @@ qemuDomainMachineIsRISCVVirt(const char *machine,
+     return false;
+ }
+ 
++static bool
++qemuDomainMachineIsLoongarch64Virt(const char *machine,
++                             const virArch arch)
++{
++    if (arch!=VIR_ARCH_LOONGARCH64)
++        return false;
++
++    if (STREQ(machine, "virt") ||
++        STRPREFIX(machine, "virt-")) {
++        return true;
++    }
++
++    return false;
++}
+ 
+ /* You should normally avoid this function and use
+  * qemuDomainIsPSeries() instead. */
+@@ -8998,6 +9017,12 @@ qemuDomainIsRISCVVirt(const virDomainDef *def)
+     return qemuDomainMachineIsRISCVVirt(def->os.machine, def->os.arch);
+ }
+ 
++bool
++qemuDomainIsLoongarch64Virt(const virDomainDef *def)
++{
++    return qemuDomainMachineIsLoongarch64Virt(def->os.machine, def->os.arch);
++}
++
+ 
+ bool
+ qemuDomainIsPSeries(const virDomainDef *def)
+diff --git a/src/qemu/qemu_domain.h b/src/qemu/qemu_domain.h
+index 1e56e50672..cb444ff06a 100644
+--- a/src/qemu/qemu_domain.h
++++ b/src/qemu/qemu_domain.h
+@@ -827,6 +827,7 @@ bool qemuDomainIsS390CCW(const virDomainDef *def);
+ bool qemuDomainIsARMVirt(const virDomainDef *def);
+ bool qemuDomainIsRISCVVirt(const virDomainDef *def);
+ bool qemuDomainIsPSeries(const virDomainDef *def);
++bool qemuDomainIsLoongarch64Virt(const virDomainDef *def);
+ bool qemuDomainIsMipsMalta(const virDomainDef *def);
+ bool qemuDomainHasPCIRoot(const virDomainDef *def);
+ bool qemuDomainHasPCIeRoot(const virDomainDef *def);
+diff --git a/src/util/virarch.c b/src/util/virarch.c
+index 01e520de73..9b981b6ced 100644
+--- a/src/util/virarch.c
++++ b/src/util/virarch.c
+@@ -83,6 +83,10 @@ static const struct virArchData {
+ 
+     { "xtensa",       32, VIR_ARCH_LITTLE_ENDIAN },
+     { "xtensaeb",     32, VIR_ARCH_BIG_ENDIAN },
++
++//  { "loong32",      32, VIR_ARCH_LITTLE_ENDIAN },
++    { "loongarch64",  64, VIR_ARCH_LITTLE_ENDIAN },
++
+ };
+ 
+ G_STATIC_ASSERT(G_N_ELEMENTS(virArchData) == VIR_ARCH_LAST);
+diff --git a/src/util/virarch.h b/src/util/virarch.h
+index 747f77c48e..3e48102f98 100644
+--- a/src/util/virarch.h
++++ b/src/util/virarch.h
+@@ -69,6 +69,9 @@ typedef enum {
+     VIR_ARCH_XTENSA,       /* XTensa      32 LE https://en.wikipedia.org/wiki/Xtensa#Processor_Cores */
+     VIR_ARCH_XTENSAEB,     /* XTensa      32 BE https://en.wikipedia.org/wiki/Xtensa#Processor_Cores */
+ 
++//  VIR_ARCH_LOONGARCH32,      /* LoongArch   32 LE https://en.wikipedia.org/wiki/LoongArch */
++    VIR_ARCH_LOONGARCH64,  /* LoongArch   64 LE https://en.wikipedia.org/wiki/LoongArch */
++
+     VIR_ARCH_LAST,
+ } virArch;
+ 
+diff --git a/src/util/virsysinfo.c b/src/util/virsysinfo.c
+index 36a861c53f..8a34c0479d 100644
+--- a/src/util/virsysinfo.c
++++ b/src/util/virsysinfo.c
+@@ -1228,6 +1228,74 @@ virSysinfoReadDMI(void)
+     return g_steal_pointer(&ret);
+ }
+ 
++static int
++virSysinfoParseLoongarch64Processor(const char *base, virSysinfoDef *ret)
++{
++    const char *cur;
++    char *eol, *tmp_base;
++    virSysinfoProcessorDef *processor;
++    char *processor_type = NULL;
++
++    if (!(tmp_base = strstr(base, "Model Name")) &&
++        !(tmp_base = strstr(base, "processor")))
++        return 0;
++
++    eol = strchr(tmp_base, '\n');
++    cur = strchr(tmp_base, ':') + 1;
++    virSkipSpaces(&cur);
++    if (eol)
++        processor_type = g_strndup(cur, eol - cur);
++
++    while ((tmp_base = strstr(base, "processor")) != NULL) {
++        base = tmp_base;
++        eol = strchr(base, '\n');
++        cur = strchr(base, ':') + 1;
++
++        VIR_EXPAND_N(ret->processor, ret->nprocessor, 1);
++        processor = &ret->processor[ret->nprocessor - 1];
++
++        virSkipSpaces(&cur);
++        if (eol)
++            processor->processor_socket_destination = g_strndup(cur,
++                                                                eol - cur);
++
++        processor->processor_type = g_strdup(processor_type);
++
++        base = cur;
++    }
++
++    VIR_FREE(processor_type);
++    return 0;
++}
++virSysinfoDef *
++virSysinfoReadLoongArch64(void);
++virSysinfoDef *
++virSysinfoReadLoongArch64(void){
++    g_autoptr(virSysinfoDef) ret = NULL;
++    g_autofree char *outbuf = NULL;
++
++    if ((ret = virSysinfoReadDMI())) {
++        if (!virSysinfoDefIsEmpty(ret))
++            return g_steal_pointer(&ret);
++        virSysinfoDefFree(ret);
++    }
++
++    virResetLastError();
++    ret = g_new0(virSysinfoDef, 1);
++
++    if (virFileReadAll(CPUINFO, CPUINFO_FILE_LEN, &outbuf) < 0) {
++        virReportError(VIR_ERR_INTERNAL_ERROR,
++                       _("Failed to open %1$s"), CPUINFO);
++        return NULL;
++    }
++
++    ret->nprocessor = 0;
++    ret->processor = NULL;
++    if (virSysinfoParseLoongarch64Processor(outbuf, ret) < 0)
++        return NULL;
++
++    return g_steal_pointer(&ret);
++}
+ 
+ /**
+  * virSysinfoRead:
+@@ -1250,6 +1318,8 @@ virSysinfoRead(void)
+      defined(__i386__) || \
+      defined(__amd64__))
+     return virSysinfoReadDMI();
++#elif defined(__loongarch64)
++    return virSysinfoReadLoongArch64();
+ #else /* WIN32 || not supported arch */
+     /*
+      * this can probably be extracted from Windows using API or registry


### PR DESCRIPTION
Tested on 3C5000L to start and manage a riscv64 guest vm successfully with libvirt.

Patches taken from
https://github.com/Xinmudotmoe/not-started-virtloongarch64 Thanks to @Xinmudotmoe !